### PR TITLE
header secrets fix

### DIFF
--- a/deploy/httpreq-webhook/templates/rbac.yaml
+++ b/deploy/httpreq-webhook/templates/rbac.yaml
@@ -131,8 +131,8 @@ roleRef:
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
-    name: {{ .Values.certManager.serviceAccountName }}
-    namespace: {{ .Values.certManager.namespace }}
+    name: {{ include "httpreq-webhook.fullname" . }}
+    namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- if .Values.secrets.role.enabled }}
 {{- range $namespace, $names := .Values.secrets.role.namespaces }}
@@ -179,7 +179,7 @@ roleRef:
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
-    name: {{ $.Values.certManager.serviceAccountName }}
-    namespace: {{ $.Values.certManager.namespace }}
+    name: {{ include "httpreq-webhook.fullname" . }}
+    namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/httpreq/httpreq.go
+++ b/httpreq/httpreq.go
@@ -5,7 +5,6 @@ package httpreq
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -148,11 +147,7 @@ func (hrs *httpReqSolver) challengeRequest(ch *acme.ChallengeRequest) error {
 		if err != nil {
 			return err
 		}
-		for key, b64 := range headerSecret.Data {
-			val, err := base64.StdEncoding.DecodeString(string(b64))
-			if err != nil {
-				return err
-			}
+		for key, val := range headerSecret.Data {
 			headers[key] = []string{string(val)}
 		}
 	}


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

- Target correct service account for secret permissions
- Secret data does not need to be base64 decoded, the go client does this automatically