### PR TITLE
Pass correct context

### DIFF
--- a/deploy/httpreq-webhook/templates/rbac.yaml
+++ b/deploy/httpreq-webhook/templates/rbac.yaml
@@ -179,7 +179,7 @@ roleRef:
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
-    name: {{ include "httpreq-webhook.fullname" . }}
+    name: {{ include "httpreq-webhook.fullname" $ }}
     namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Inside a range context. Must pass $ instead of .