### PR TITLE
Support hostNetwork mode for EKS custom CNI deployment

### DIFF
--- a/deploy/httpreq-webhook/templates/deployment.yaml
+++ b/deploy/httpreq-webhook/templates/deployment.yaml
@@ -14,6 +14,11 @@ spec:
     matchLabels:
       app: {{ include "httpreq-webhook.name" . }}
       release: {{ .Release.Name }}
+
+  {{- if .Values.strategy }}
+  strategy:
+    {{ toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -35,6 +40,7 @@ spec:
             {{- if not (kindIs "invalid" .Values.logLevel) }}
             - --v={{ .Values.logLevel }}
             {{- end }}
+            - --secure-port={{ .securePort }}
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
@@ -43,7 +49,7 @@ spec:
             {{- end }}
           ports:
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.securePort }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -65,6 +71,12 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "httpreq-webhook.servingCertificate" . }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if or .Values.dnsPolicy .Values.hostNetwork }}
+      dnsPolicy: {{ .Values.dnsPolicy | default "ClusterFirstWithHostNet" }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}

--- a/deploy/httpreq-webhook/values.yaml
+++ b/deploy/httpreq-webhook/values.yaml
@@ -44,6 +44,21 @@ service:
   type: ClusterIP
   port: 443
 
+# Required for EKS with custom CNI
+# https://cert-manager.io/docs/concepts/webhook/#webhook-connection-problems-on-aws-eks
+hostNetwork: false
+dnsPolicy:  # Default to ClusterFirstWithHostNet if hostNetwork is true
+securePort: 12443
+
+# Deployment update strategy
+# With hostNetwork, you may want to set maxUnavailable 1 so pod can rebind to same port on the node
+strategy:
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 0
+  #   maxUnavailable: 1
+
+
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

EKS with custom CNI requires webhook pods to run with `hostNetwork: true` in order for them to be reachable by the k8s ApiServer.

Add option to set hostNetwork, as well as use a custom securePort so as not to bind 443 on the host.
Add deployment update strategy value to enable controlling updates. By default the pod would be unable to land on the same node as the previous version since it will still have the hostPort bound.